### PR TITLE
Remove out of place semi-colon

### DIFF
--- a/client/src/components/Timeline/index.js
+++ b/client/src/components/Timeline/index.js
@@ -14,7 +14,7 @@ class Timeline extends Component {
       <div>
       <h1>Timeline</h1>
       
-      <PostGroup PostsLocation="LatestPosts" />;
+      <PostGroup PostsLocation="LatestPosts" />
       </div>
     )
   }


### PR DESCRIPTION
At the bottom of the timeline page, there is a semi-colon. Removing it here fixes this :)